### PR TITLE
Nilscarlson/no name counters

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -209,14 +209,10 @@ class ModelClass(Model):
         return _re_invalid_identifier.sub('_', name)
 
     def _add_attribute(self, attrname, value):
-        attrname = tempname = self._convert_to_valid_identifier(attrname)
-        counter = 1
-        while tempname in self.attributes:
-            tempname = attrname + str(counter)
-            counter += 1
+        attrname = self._convert_to_valid_identifier(attrname)
 
-        self.attributes[tempname] = value
-        return tempname
+        self.attributes[attrname] = value
+        return attrname
 
     def add_imports(self, collector):
         super(ModelClass, self).add_imports(collector)

--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -209,10 +209,30 @@ class ModelClass(Model):
         return _re_invalid_identifier.sub('_', name)
 
     def _add_attribute(self, attrname, value):
-        attrname = self._convert_to_valid_identifier(attrname)
+        attrname = tempname = self._convert_to_valid_identifier(attrname)
+        counter = 1
+        while tempname in self.attributes:
+            tempname = attrname + str(counter)
+            # These prints have been left knowing that sys.stdout is somehow
+            # prematurely redirected to the 'out_file', and thus rather
+            # than correctly printing the warning, it is added as the first
+            # line of the output file.
+            # TODO: correctly redirect prints to stdout, while keeping final
+            # render as being written to the output file
+            print(f'#WARNING: {self.name} already has attribute {attrname}, '
+                  +f'renaming to {tempname}\n')
+            counter += 1
 
+        self.attributes[tempname] = value
+        return tempname
+
+    def _set_attribute(self, attrname, value):
+        if attrname in self.attributes:
+            # TODO: correctly redirect prints to stdout, while keeping final
+            # render as being written to the output file
+            print(f'#WARNING: {self.name} already has attribute {attrname}, '
+                  +f'overriding with forced relationship')
         self.attributes[attrname] = value
-        return attrname
 
     def add_imports(self, collector):
         super(ModelClass, self).add_imports(collector)
@@ -324,6 +344,7 @@ class CodeGenerator(object):
 
 {configure_mappers_call}
 """
+
 
     def __init__(self, metadata, noindexes=False, noconstraints=False, nojoined=False, noinflect=False,
                  noclasses=False, indentation='    ', model_separator='\n\n',
@@ -622,7 +643,12 @@ class CodeGenerator(object):
             for relation in relations:
                 relationship_ = Relationship(parent, relation['child'])
                 relationship_.kwargs = relation['kwargs']
-                model._add_attribute(relation['name'], relationship_)
+                # For each forced attribute argument, add/override that
+                # attribute in the table.
+                # Note: arguments that conflict by attempting to add
+                # the same name twice are caught before code generation begins
+                # (within main.py).
+                model._set_attribute(relation['name'], relationship_)
 
         # Stes the desired model(s) to instantiate the flask-login classes UserMixin/RoleMixin
         # (as set by the --loginuser and --loginrole command options)

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -43,15 +43,23 @@ def main():
         parser.print_help()
         return
     _relationship = dict()
+    _rel_set = set()
     args.relationship = [] if args.relationship is None else args.relationship
-    for rel in args.relationship:
-        key = rel[0]
-        val = { 'child' : rel[1]
-              ,'name' : rel[2]
-              , 'kwargs' : json.loads(rel[3])
+    for (key, child, name, kwargs) in args.relationship:
+        val = { 'child' : child,
+                'name' : name,
+                'kwargs' : json.loads(kwargs)
               }
         if not (key in _relationship):
             _relationship[key] = []
+        # There must not be conflicts where a table is given
+        # forced relationships that share an an attribute name
+        if (key, name) in _rel_set:
+            raise KeyError(f'Tried to create a forced relationship "{name}" '
+                           +f'within {key}, but another forced relationship '
+                           +f'exists in {key} with the same name.')
+        _rel_set.add((key, name))
+
         _relationship[key].append(val)
     args.relationship = _relationship
     engine = create_engine(args.url)


### PR DESCRIPTION
Alright I am going to prioritize my other task before I come back and figure out what is going on with stdout being redirected to the out file (not even `sys.stdout.write()` seems to go the correct place).

Let me know if this seems to be an alright solution, it has the properties we want of:
* no conflicts -> generates fine, no warnings
* conflict between sql and forced rel -> generates fine, does have warning (warning here might be excessive, could remove)
* conflict between sql and sql -> generates fine, increments name with counter does have warning
* conflict between forced rel and forced rel -> blows up, informing programmer which relationship in which table was likely duplicated

Lmk what you think! 
Also sorry that the branch name is now misleading, haha