### PR TITLE
Remove  todos

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -213,13 +213,7 @@ class ModelClass(Model):
         counter = 1
         while tempname in self.attributes:
             tempname = attrname + str(counter)
-            # These prints have been left knowing that sys.stdout is somehow
-            # prematurely redirected to the 'out_file', and thus rather
-            # than correctly printing the warning, it is added as the first
-            # line of the output file.
-            # TODO: correctly redirect prints to stdout, while keeping final
-            # render as being written to the output file
-            print(f'#WARNING: {self.name} already has attribute {attrname}, '
+            print(f'WARNING: {self.name} already has attribute {attrname}, '
                   +f'renaming to {tempname}\n')
             counter += 1
 
@@ -228,9 +222,7 @@ class ModelClass(Model):
 
     def _set_attribute(self, attrname, value):
         if attrname in self.attributes:
-            # TODO: correctly redirect prints to stdout, while keeping final
-            # render as being written to the output file
-            print(f'#WARNING: {self.name} already has attribute {attrname}, '
+            print(f'WARNING: {self.name} already has attribute {attrname}, '
                   +f'overriding with forced relationship')
         self.attributes[attrname] = value
 

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, division, print_function, absolute_import
 import argparse
 import codecs
 import sys


### PR DESCRIPTION
Turns out it wasn't a sqlacodegen error, we just weren't using it properly. We were just taking the output and piping it to a new file, works fine when you give it an `outfile` argument.

Changes made on `neos-api` branch  (https://github.com/VoterLabsInc/upshot-api/pull/288)